### PR TITLE
README: Fix broken logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://bitvavo.com"><img src="https://bitvavo.com/media/images/logo/bitvavoGeneral.svg" width="600" title="Bitvavo Logo"></a>
+  <a href="https://bitvavo.com"><img src="https://bitvavo.com/assets/img/press/logo/dark/svg/full.svg" width="600" title="Bitvavo Logo"></a>
 </p>
 
 # Python Bitvavo Api


### PR DESCRIPTION
The current logo in the README is broken, because the link to the img
404s:
https://bitvavo.com/media/images/logo/bitvavoGeneral.svg

Replaced with:
https://bitvavo.com/assets/img/press/logo/dark/svg/full.svg

Before:
![image](https://user-images.githubusercontent.com/1130872/72066551-2f406080-32e1-11ea-80fe-7b8d15f1f0d0.png)

After:
![image](https://user-images.githubusercontent.com/1130872/72066599-5008b600-32e1-11ea-98d3-b14a6e44c868.png)
