### PR TITLE
🐛  Added __init__.py for pip package creation

### DIFF
--- a/python_bitvavo_api/__init__.py
+++ b/python_bitvavo_api/__init__.py
@@ -1,0 +1,1 @@
+name = "pythonBitvavoApi"


### PR DESCRIPTION
Package would not build correctly without this file. Not necessary when using this repo as startpoint, already fixed on pypi.org