### PR TITLE
API response error when calling depositAssets()

### DIFF
--- a/python_bitvavo_api/bitvavo.py
+++ b/python_bitvavo_api/bitvavo.py
@@ -327,7 +327,7 @@ class Bitvavo:
 
   def depositAssets(self, symbol):
     postfix = createPostfix({ 'symbol': symbol })
-    return self.privateRequest('/depositAssets', postfix, {}, 'GET')
+    return self.privateRequest('/deposit', postfix, {}, 'GET')
 
   # optional body parameters: paymentId, internal, addWithdrawalFee
   def withdrawAssets(self, symbol, amount, address, body):


### PR DESCRIPTION
From the [documentation](https://docs.bitvavo.com/#tag/Account/paths/~1balance/get), this code return an error:

```python
from python_bitvavo_api.bitvavo import Bitvavo

bitvavo = Bitvavo('<APIKEY>', '<APISECRET>')
response = bitvavo.depositAssets('BTC')
print(response)
```

Response:
```
{'errorCode': 110, 'error': 'Invalid endpoint. Please check url and HTTP method.'}
```

This PR change the URL for the depositAssets method to `/deposit`, which solve the error.