### PR TITLE
fix: specify version range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-.DS_Store
+### Python ###
 dist
-python_bitvavo_api.egg-info
+*.egg-info
+*.whl
+
+### Mac OS ###
+.DS_Store
+
+### IDEs ###
 .idea
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(
     url="https://github.com/bitvavo/python-bitvavo-api",
     packages=find_packages(),
     install_requires=[
-        'websocket-client',
-        'requests==2.31.0',
+        'websocket-client>=1.6.0,<2.0.0',
+        'requests>=2.31.0,<3.0.0',
         'setuptools'
     ],
     classifiers=[


### PR DESCRIPTION
Changes the configuration of the Python SDK to allow using a version range for the dependencies.

This should prevent us from using code which contains a vulnerability.