### PR TITLE
fix(websocket): improve error and close handling

### DIFF
--- a/python_bitvavo_api/bitvavo.py
+++ b/python_bitvavo_api/bitvavo.py
@@ -525,11 +525,10 @@ class Bitvavo:
       if 'error' in self.callbacks:
         self.callbacks['error'](error)
       else:
-        errorToConsole(error)
+        errorToConsole(repr(error))
 
-    def on_close(self, ws):
-      self.receiveThread.exit()
-      debugToConsole('Closed Websocket.')
+    def on_close(self, ws, close_status_code=None, close_msg=None):
+      debugToConsole(f"Closed Websocket. code={close_status_code} reason={close_msg}")
 
     def checkReconnect(self):
       if('subscriptionTicker' in self.callbacks):


### PR DESCRIPTION
- Use repr() when logging errors to ensure useful output even for non-string errors
- Update on_close signature to accept (code, reason) for compatibility with newer websocket-client
- Remove self.receiveThread.exit() since the exit method does not exist in receiveThread
- Log close code and reason for easier debugging